### PR TITLE
Can launch the plugin several times without clean maven command.

### DIFF
--- a/src/main/java/fr/inria/gforge/spoon/logging/ReportFactory.java
+++ b/src/main/java/fr/inria/gforge/spoon/logging/ReportFactory.java
@@ -4,6 +4,7 @@ import fr.inria.gforge.spoon.Spoon;
 import fr.inria.gforge.spoon.util.LogWrapper;
 
 import java.io.File;
+import java.util.Calendar;
 
 public final class ReportFactory {
 
@@ -14,14 +15,12 @@ public final class ReportFactory {
 	 * Get a {@link fr.inria.gforge.spoon.logging.ReportBuilder} to build a report.
 	 */
 	public static ReportBuilder newReportBuilder(Spoon spoon) {
+		final long timestamp = Calendar.getInstance().getTimeInMillis();
 		final String resultFilename = spoon.getProject().getBuild().getDirectory()
 				+ File.separator + "spoon-maven-plugin"
-				+ File.separator + "result-spoon.xml";
+				+ File.separator + "result-spoon-" + timestamp + ".xml";
 		final File resultFile = new File(resultFilename);
 		LogWrapper.info(spoon, String.format("Spoon report directory: %s", resultFile.getParentFile().getAbsolutePath()));
-		if (resultFile.exists()) {
-			throw new RuntimeException("Project already spooned.");
-		}
 		return new ReportBuilderImpl(resultFile);
 	}
 

--- a/src/test/java/fr/inria/gforge/spoon/mojo/SpoonMojoTest.java
+++ b/src/test/java/fr/inria/gforge/spoon/mojo/SpoonMojoTest.java
@@ -1,11 +1,13 @@
 package fr.inria.gforge.spoon.mojo;
 
+import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.apache.maven.plugin.testing.MojoRule;
 import org.apache.maven.plugin.testing.resources.TestResources;
 import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileFilter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -20,8 +22,12 @@ public final class SpoonMojoTest {
 		File basedir = resources.getBasedir("hello-world");
 		rule.executeMojo(basedir, "generate");
 
-		File resultFile = new File(basedir, "target/spoon-maven-plugin/result-spoon.xml");
-		assertThat(resultFile).exists();
+		final File dirOutputResults = new File(basedir, "target/spoon-maven-plugin");
+		assertThat(dirOutputResults).exists();
+
+		final File[] files = dirOutputResults.listFiles();
+		assertThat(files.length).isEqualTo(1);
+		assertThat(files[0].getName()).startsWith("result-spoon");
 	}
 
 	@Test
@@ -29,9 +35,15 @@ public final class SpoonMojoTest {
 		File basedir = resources.getBasedir("processor");
 		rule.executeMojo(basedir, "generate");
 
-		File resultFile = new File(basedir, "target/spoon-maven-plugin/result-spoon.xml");
-		File resultFileProcessor = new File(basedir, "target/spoon-maven-plugin/spoon-nb-statement.txt");
-		assertThat(resultFile).exists();
+		final File dirOutputResults = new File(basedir, "target/spoon-maven-plugin");
+		assertThat(dirOutputResults).exists();
+
+		final WildcardFileFilter filter = new WildcardFileFilter("result-spoon-*.xml");
+		final File[] files = dirOutputResults.listFiles((FileFilter) filter);
+		assertThat(files.length).isEqualTo(1);
+		assertThat(files[0].getName()).startsWith("result-spoon");
+
+		final File resultFileProcessor = new File(basedir, "target/spoon-maven-plugin/spoon-nb-statement.txt");
 		assertThat(resultFileProcessor).exists();
 	}
 
@@ -40,9 +52,15 @@ public final class SpoonMojoTest {
 		File basedir = resources.getBasedir("custom-configuration");
 		rule.executeMojo(basedir, "generate");
 
-		File resultFile = new File(basedir, "target/spoon-maven-plugin/result-spoon.xml");
+		final File dirOutputResults = new File(basedir, "target/spoon-maven-plugin");
+		assertThat(dirOutputResults).exists();
+
+		final WildcardFileFilter filter = new WildcardFileFilter("result-spoon-*.xml");
+		final File[] files = dirOutputResults.listFiles((FileFilter) filter);
+		assertThat(files.length).isEqualTo(1);
+		assertThat(files[0].getName()).startsWith("result-spoon");
+
 		File generateFiles = new File(basedir, "target/generate-source-with-spoon");
-		assertThat(resultFile).exists();
 		assertThat(generateFiles).exists();
 	}
 }


### PR DESCRIPTION
Before, when the plugin identifies a result file in the build directory (target), the plugin stopped and notified the developer that the project is already spooned. Now, the result file contains a timestamp in its filename and the project can install several times a project given without any clean command.