### PR TITLE
Handles maven plugin to spoon source code generated by spoon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,110 +2,94 @@
 
 # Spoon maven plugin
 
-A maven plugin to run spoon on a target project.
+A maven plugin to run source code transformations using spoon on a project built with Maven.
 
-## Usage
+## Basic usage
 
-To execute Spoon maven plugin, you must declare it on the `build` tag in the `pom.xml` file of your project and specify an execution during the `generate-source` phase of the maven lifecycle.
+To use spoon-maven-plugin, you need to declare it on the `build` tag in the `pom.xml` file of your project and specify an execution during the `generate-source` phase of the maven lifecycle.
 
 The usage below is the minimum to execute the plugin and run spoon on your project.
 
-```
+```xml
 <plugin>
-    <groupId>fr.inria.gforge.spoon</groupId>
-    <artifactId>spoon-maven-plugin</artifactId>
-    <version>${plugin.spoon.version}</version>
-    <executions>
-        <execution>
-            <phase>generate-sources</phase>
-            <goals>
-                <goal>generate</goal>
-            </goals>
-        </execution>
-    </executions>
+  <groupId>fr.inria.gforge.spoon</groupId>
+  <artifactId>spoon-maven-plugin</artifactId>
+  <version>${plugin.spoon.version}</version>
+  <executions>
+    <execution>
+      <phase>generate-sources</phase>
+      <goals>
+        <goal>generate</goal>
+      </goals>
+    </execution>
+  </executions>
 </plugin>
 ```
 
-After that, you can launch the command `mvn clean install` and the plugin will be automatically called.
+Consequently, when `mvn clean install` is run on your project, the source code is first rewritten by spoon before compilation.
 
-## Inputs
+## How to add processors?
 
-You can configure some parameters in the plugin in the `configuration` tag of your plugin declaration:
+Spoon can use processors to analyse and transform source code.
 
-```
-<plugin>
-    <groupId>fr.inria.gforge.spoon</groupId>
-    <artifactId>spoon-maven-plugin</artifactId>
-    <version>${plugin.spoon.version}</version>
-    <executions>
-        <execution>
-            <phase>generate-sources</phase>
-            <goals>
-                <goal>generate</goal>
-            </goals>
-        </execution>
-    </executions>
-    <configuration>
-        <!-- Your configuration -->
-    </configuration>
-</plugin>
-```
+To add processors, one must:
 
-### Source and output folder
+1. add a dependency in the `plugin` block.
+2. add a processor with its full qualified name in the `configuration` block.
 
-You can specify at spoon its input and output directories with, respectively, `srcFolder` and `outFolder` tags.
+In the example below, we add processor `fr.inria.gforge.spoon.processors.CountStatementProcessor` and the dependency necessary to locate the processor.
 
-### Formatting
-
-You can preserving the formatting of your source code with the boolean tag `preserveFormatting`.
-
-### Processors
-
-Spoon can use processors to process some codes during its analysis of a source code. The plugin supports processors and can be specified as configuration in the declaration of the plugin.
-
-In the next usage, we would like to launch the processor name `fr.inria.gforge.spoon.processors.CountStatementProcessor` (you must specify the full qualified name) and the dependency necessary to locate the processor.
-
-```
+```xml
 <configuration>
-    <processors>
-        <processor>fr.inria.gforge.spoon.processors.CountStatementProcessor</processor>
-    </processors>
+  <processors>
+    <processor>
+      fr.inria.gforge.spoon.processors.CountStatementProcessor
+    </processor>
+  </processors>
 </configuration>
 <dependencies>
-    <dependency>
-        <groupId>fr.inria.gforge.spoon</groupId>
-        <artifactId>spoon-processors</artifactId>
-        <version>1.0-SNAPSHOT</version>
-    </dependency>
+  <dependency>
+    <groupId>fr.inria.gforge.spoon</groupId>
+    <artifactId>spoon-processors</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </dependency>
 </dependencies>
 ```
 
-## Custom version for Spoon
+## How to change source and output folder?
+
+You can specify at spoon its input and output directories with, respectively, `srcFolder` and `outFolder` tags.
+
+## How to compile original sources?
+
+By default, spoon generate your source code and compile these sources but you can specify at the plugin that you want to compile your original sources with the tag `compileOriginalSources` sets to true.
+
+## How to specify a custom version for Spoon?
 
 Spoon maven plugin defines a default value for spoon's version but you can override it to another one.
 
 For example, if you would like the version 2.4 of spoon and not the version 3.0, you must add the dependency below.
 
-```
+```xml
 <plugin>
-    <groupId>fr.inria.gforge.spoon</groupId>
-    <artifactId>spoon-maven-plugin</artifactId>
-    <version>${plugin.spoon.version}</version>
-    <executions>
-        <execution>
-            <phase>generate-sources</phase>
-            <goals>
-                <goal>generate</goal>
-            </goals>
-        </execution>
-    </executions>
-    <dependencies>
-        <dependency>
-            <groupId>fr.inria.gforge.spoon</groupId>
-            <artifactId>spoon-core</artifactId>
-            <version>2.4</version>
-        </dependency>
-    </dependencies>
+  <groupId>fr.inria.gforge.spoon</groupId>
+  <artifactId>spoon-maven-plugin</artifactId>
+  <version>${plugin.spoon.version}</version>
+  <executions>
+    <execution>
+      <phase>generate-sources</phase>
+      <goals>
+        <goal>generate</goal>
+      </goals>
+    </execution>
+  </executions>
+  <dependencies>
+    <dependency>
+      <groupId>fr.inria.gforge.spoon</groupId>
+      <artifactId>spoon-core</artifactId>
+      <version>2.4</version>
+    </dependency>
+  </dependencies>
 </plugin>
 ```
 
@@ -119,4 +103,30 @@ The plugin creates some reports about its context and the execution of spoon on 
 
 ## Download
 
-The plugin is available with a snapshot and a release version on Maven Central.
+Stable version available on Maven Central:
+
+```xml
+<dependency>
+  <groupId>fr.inria.gforge.spoon</groupId>
+  <artifactId>spoon-maven-plugin</artifactId>
+  <version>2.0</version>
+</dependency>
+```
+
+Snapshot version:
+
+```xml
+<pluginRepositories>
+  <pluginRepository>
+    <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+  </pluginRepository>
+</pluginRepositories>
+<dependencies>
+	<dependency>
+	  <groupId>fr.inria.gforge.spoon</groupId>
+	  <artifactId>spoon-maven-plugin</artifactId>
+	  <version>3.0-SNAPSHOT</version>
+	</dependency>
+</dependencies>
+```

--- a/src/main/java/fr/inria/gforge/spoon/Spoon.java
+++ b/src/main/java/fr/inria/gforge/spoon/Spoon.java
@@ -70,6 +70,13 @@ public class Spoon extends AbstractMojo {
 			defaultValue = "false")
 	private boolean debug;
 	/**
+	 * Active the compilation of original sources.
+	 */
+	@Parameter(
+			property = "Compile original sources and not source spooned",
+			defaultValue = "false")
+	private boolean compileOriginalSources;
+	/**
 	 * Project spooned with maven information.
 	 */
 	@Parameter(
@@ -164,6 +171,10 @@ public class Spoon extends AbstractMojo {
 
 	public boolean isDebug() {
 		return debug;
+	}
+
+	public boolean isCompileOriginalSources() {
+		return compileOriginalSources;
 	}
 
 	public MavenProject getProject() {

--- a/src/main/java/fr/inria/gforge/spoon/configuration/AbstractSpoonConfigurationBuilder.java
+++ b/src/main/java/fr/inria/gforge/spoon/configuration/AbstractSpoonConfigurationBuilder.java
@@ -57,6 +57,10 @@ abstract class AbstractSpoonConfigurationBuilder
 
 		parameters.add("-o");
 		parameters.add(spoon.getOutFolder().getAbsolutePath());
+		if (!spoon.isCompileOriginalSources()) {
+			spoon.getProject().getCompileSourceRoots().clear();
+			spoon.getProject().addCompileSourceRoot(spoon.getOutFolder().getAbsolutePath());
+		}
 		reportBuilder.setOutput(spoon.getOutFolder().getAbsolutePath());
 		return this;
 	}


### PR DESCRIPTION
Now, by default, the plugin will compile the source code generated by spoon. If the developer would like to compile original sources, he must switch the parameter compileOriginalSources to true.