### PR TITLE
Add parameter to switch off some spoon errors

### DIFF
--- a/src/main/java/fr/inria/gforge/spoon/SpoonMojoGenerate.java
+++ b/src/main/java/fr/inria/gforge/spoon/SpoonMojoGenerate.java
@@ -127,6 +127,12 @@ public class SpoonMojoGenerate extends AbstractMojo {
 	)
 	private boolean skipGeneratedSources;
 
+	@Parameter(
+			property = "Prevent the build from crashing in case of Spoon error: a warning will only be triggered",
+			defaultValue = "false"
+	)
+	private boolean skipSpoonErrors;
+
 	@Parameter
 	private ProcessorProperties[] processorProperties;
 
@@ -212,7 +218,11 @@ public class SpoonMojoGenerate extends AbstractMojo {
 			performance.execute();
 			reportBuilder.buildReport();
 		} catch (SpoonMavenPluginException e) {
-	    	LogWrapper.warn(this, e.getMessage()+"\n This project will be ignored.", e);
+	    	if (this.getSkipSpoonErrors()) {
+				LogWrapper.warn(this, e.getMessage()+"\n This project will be ignored.", e);
+			} else {
+				throw new MojoExecutionException(e.getMessage(), e);
+			}
 		} catch (Exception e) {
 			LogWrapper.error(this, e.getMessage(), e);
 			throw new MojoExecutionException(e.getMessage(), e);
@@ -323,5 +333,9 @@ public class SpoonMojoGenerate extends AbstractMojo {
 
 	public boolean getSkipGeneratedSources() {
 		return skipGeneratedSources;
+	}
+
+	public boolean getSkipSpoonErrors() {
+		return skipSpoonErrors;
 	}
 }

--- a/src/test/java/fr/inria/gforge/spoon/mojo/SpoonMojoTest.java
+++ b/src/test/java/fr/inria/gforge/spoon/mojo/SpoonMojoTest.java
@@ -1,5 +1,6 @@
 package fr.inria.gforge.spoon.mojo;
 
+import fr.inria.gforge.spoon.configuration.SpoonMavenPluginException;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -136,6 +137,28 @@ public final class SpoonMojoTest {
 		} catch (MojoExecutionException e) {
 			assertThat(e.getCause().getCause()).isInstanceOf(SpoonException.class);
 		}
+
+		final File dirOutputResults = new File(basedir, "target/spoon-maven-plugin");
+		assertThat(dirOutputResults).doesNotExist();
+	}
+
+	@Test
+	public void testSpoonConfigThrowException() throws Exception {
+		File basedir = resources.getBasedir("hello-world-config-exception");
+		try {
+			rule.executeMojo(basedir, "generate");
+		} catch (MojoExecutionException e) {
+			assertThat(e.getCause()).isInstanceOf(SpoonMavenPluginException.class);
+		}
+
+		final File dirOutputResults = new File(basedir, "target/spoon-maven-plugin");
+		assertThat(dirOutputResults).doesNotExist();
+	}
+
+	@Test
+	public void testSpoonConfigCatchException() throws Exception {
+		File basedir = resources.getBasedir("hello-world-config-exception-ignored");
+		rule.executeMojo(basedir, "generate");
 
 		final File dirOutputResults = new File(basedir, "target/spoon-maven-plugin");
 		assertThat(dirOutputResults).doesNotExist();

--- a/src/test/projects/hello-world-config-exception-ignored/pom.xml
+++ b/src/test/projects/hello-world-config-exception-ignored/pom.xml
@@ -13,6 +13,7 @@
         <artifactId>spoon-maven-plugin</artifactId>
         <configuration>
           <skipSpoonErrors>true</skipSpoonErrors>
+          <srcFolder>./foo</srcFolder>
         </configuration>
       </plugin>
     </plugins>

--- a/src/test/projects/hello-world-config-exception-ignored/src/main/java/fr/inria/gforge/spoon/App.java
+++ b/src/test/projects/hello-world-config-exception-ignored/src/main/java/fr/inria/gforge/spoon/App.java
@@ -1,0 +1,10 @@
+package fr.inria.gforge.spoon;
+
+/**
+ * Hello world!
+ */
+public class App {
+	public static void main(String[] args) {
+		System.out.println("Hello World!");
+	}
+}

--- a/src/test/projects/hello-world-config-exception/pom.xml
+++ b/src/test/projects/hello-world-config-exception/pom.xml
@@ -12,7 +12,7 @@
         <groupId>fr.inria.gforge.spoon</groupId>
         <artifactId>spoon-maven-plugin</artifactId>
         <configuration>
-          <skipSpoonErrors>true</skipSpoonErrors>
+          <srcFolder>./foo</srcFolder>
         </configuration>
       </plugin>
     </plugins>

--- a/src/test/projects/hello-world-config-exception/src/main/java/fr/inria/gforge/spoon/App.java
+++ b/src/test/projects/hello-world-config-exception/src/main/java/fr/inria/gforge/spoon/App.java
@@ -1,0 +1,10 @@
+package fr.inria.gforge.spoon;
+
+/**
+ * Hello world!
+ */
+public class App {
+	public static void main(String[] args) {
+		System.out.println("Hello World!");
+	}
+}


### PR DESCRIPTION
This PR is a second thought after doing #57: when working in #58 when I expected an error I got nothing which was a bit disturbing, as @tmortagne had mentionned before.

So I propose to add a parameter `skipSpoonErrors` to explicitely indicate to skip __some__ Spoon errors.
And by __some__ it means that only errors when configuring Spoon will be catch: all errors coming from Spoon execution will be thrown. This was already the behaviour after #57 so I just did not change it, I don't know if it can be a problem for you @tmortagne. 