### PR TITLE
Feature: java 9/10 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <spoon.version>7.0.0</spoon.version>
     <commons-io.version>2.6</commons-io.version>
     <jaxb-api.version>2.2.11</jaxb-api.version>
+    <jaxb-runtime.version>2.3.1</jaxb-runtime.version>
     <maven-plugin-annotations.version>3.5</maven-plugin-annotations.version>
     <maven-project.version>2.2.1</maven-project.version>
     <maven-plugin-api>3.3.9</maven-plugin-api>
@@ -125,6 +126,12 @@
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
       <version>${jaxb-api.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>${jaxb-runtime.version}</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/src/main/java/fr/inria/gforge/spoon/configuration/AbstractSpoonConfigurationBuilder.java
+++ b/src/main/java/fr/inria/gforge/spoon/configuration/AbstractSpoonConfigurationBuilder.java
@@ -51,6 +51,8 @@ abstract class AbstractSpoonConfigurationBuilder
 			}
 		}
 
+		srcDir.removeIf(file -> !file.exists());
+
 		if (srcDir.isEmpty()) {
 			throw new SpoonMavenPluginException(String.format("No source directory for %s project.", spoon.getProject().getName()));
 		}
@@ -58,9 +60,6 @@ abstract class AbstractSpoonConfigurationBuilder
 		String inputs = "";
 		for (int i = 0; i < srcDir.size(); i++) {
 			File file = srcDir.get(i);
-			if (!file.exists()) {
-				throw new SpoonMavenPluginException(file.getName() + " don't exist.");
-			}
 			inputs += file.getAbsolutePath();
 			if (i != srcDir.size() - 1) {
 				inputs += File.pathSeparatorChar;


### PR DESCRIPTION
While spoon is compatible to java 9 and 10 the spoon-maven-plugin is not. I made the least changes possible to make the project running again.

The plugin was building and running with java 9/10 after the changes to `pom.xml` and `SpoonMojoGenerate.java`. But testing with a real project showed that there was another issue regarding a not found directory, thus I had to make the change in `AbstractSpoonConfigurationBuilder.java`. That change made the build process pass and spoon did a proper job 👍