### PR TITLE
chore: Use OW2 Nexus snapshot repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,10 +40,10 @@
 
   <repositories>
     <repository>
-      <id>maven.inria.fr-snapshot</id>
-      <name>Maven Repository for Spoon Snapshot</name>
-      <url>http://maven.inria.fr/artifactory/spoon-public-snapshot/</url>
-      <snapshots />
+      <id>ow2.org-snapshot</id>
+      <name>Maven Repository for Spoon Snapshots</name>
+      <url>https://repository.ow2.org/nexus/content/repositories/snapshots/</url>
+      <snapshots/>
     </repository>
   </repositories>
 


### PR DESCRIPTION
This is related to inria/spoon#3775

Jenkins CI is pulling snapshots from the old snapshot repository, and is therefore not getting the new ones. This causes all tests to run with the latest beta version of Spoon instead of the snapshot, which in turn delays feedback on errors.

I've not been able to find a way to override the snapshot repository given in spoon-maven-plugin, so we need to update the repository here.