### PR TITLE
review: chore: Remove the OW2 snapshot repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,15 +38,6 @@
     <additionalparam>-Xdoclint:none</additionalparam>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>maven.inria.fr-snapshot</id>
-      <name>Maven Repository for Spoon Snapshot</name>
-      <url>http://maven.inria.fr/artifactory/spoon-public-snapshot/</url>
-      <snapshots />
-    </repository>
-  </repositories>
-
   <scm>
     <url>https://github.com/SpoonLabs/spoon-maven-plugin</url>
     <connection>scm:git:git://github.com/SpoonLabs/spoon-maven-plugin.git</connection>


### PR DESCRIPTION
As far as I can tell, there is no good reason to define the snapshot repository in this project's pom file.

See also inria/spoon#3216 and inria/spoon#3864