### PR TITLE
fix: add a workaround to avoid InaccessibleObjectException when adding artifact URL to system classloader

### DIFF
--- a/src/main/java/fr/inria/gforge/spoon/util/ClasspathHacker.java
+++ b/src/main/java/fr/inria/gforge/spoon/util/ClasspathHacker.java
@@ -1,27 +1,67 @@
 package fr.inria.gforge.spoon.util;
 
-import java.io.File;
+import sun.misc.Unsafe;
+
 import java.io.IOException;
-import java.lang.reflect.Method;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.*;
 import java.net.URL;
 import java.net.URLClassLoader;
 
 public final class ClasspathHacker {
+
+	private static final Unsafe unsafeOp;
+
+	static {
+		Unsafe unsafe = null;
+		for (Field f : Unsafe.class.getDeclaredFields()) {
+			try {
+				if (f.getType() == Unsafe.class && Modifier.isStatic(f.getModifiers())) {
+					f.setAccessible(true);
+					unsafe = (Unsafe) f.get(null);
+				}
+			} catch (Exception ignored) {
+			}
+		}
+		unsafeOp = unsafe;
+	}
+
 	private ClasspathHacker() {
 	}
 
 	public static void addURL(URLClassLoader urlClassLoader, URL u) throws IOException {
 		Class<URLClassLoader> classLoaderClass = URLClassLoader.class;
-
 		try {
-			Method method = classLoaderClass.getDeclaredMethod("addURL",
-					new Class[] { URL.class });
-			method.setAccessible(true);
-			method.invoke(urlClassLoader, new Object[] { u });
-		} catch (Throwable t) {
-			t.printStackTrace();
-			throw new IOException(
-					"Error, could not add URL to system classloader");
+			Method method = classLoaderClass.getDeclaredMethod("addURL", URL.class);
+			try {
+				method.setAccessible(true);
+				method.invoke(urlClassLoader, u);
+			} catch (InaccessibleObjectException e) {
+				if (unsafeOp != null)
+					try {
+						getPrivilegedMethodHandle(method).bindTo(urlClassLoader);
+					} catch (Exception ex) {
+						throw new IOException("Error, could not add URL to system classloader", e);
+					}
+			} catch (InvocationTargetException | IllegalAccessException e) {
+				throw new IOException("Error, could not add URL to system classloader", e);
+			}
+		} catch (NoSuchMethodException e) {
+			throw new IOException("Error, could not add URL to system classloader", e);
 		}
+	}
+
+	// Get a privileged method handle for a given method to provide support for java 16+.
+	private static MethodHandle getPrivilegedMethodHandle(Method method) throws IllegalAccessException {
+		for (Field trustedLookup : MethodHandles.Lookup.class.getDeclaredFields()) {
+			if (trustedLookup.getType() != MethodHandles.Lookup.class || !Modifier.isStatic(trustedLookup.getModifiers())
+					|| trustedLookup.isSynthetic())
+				continue;
+			MethodHandles.Lookup lookup = (MethodHandles.Lookup) unsafeOp
+					.getObject(unsafeOp.staticFieldBase(trustedLookup), unsafeOp.staticFieldOffset(trustedLookup));
+			return lookup.unreflect(method);
+		}
+		throw new RuntimeException("Error, could not get privileged method handle.");
 	}
 }


### PR DESCRIPTION
- Fixes #https://github.com/INRIA/spoon/issues/4251

This PR adds a workaround to provide support for java 16+. This solution uses sun.misc.Unsafe which is not highly recommended as it is not a supported public java interface and can be removed in future releases, And also because it is used to break the rules. (https://blogs.oracle.com/javamagazine/post/the-unsafe-class-unsafe-at-any-speed). 
But as far as I know, unless we change the current way of adding artifacts to the classpath using reflective access, there are not any proper solutions. However, we can change the current implementation and use java instrumentation instead, and that would be a better way to address this issue.
This workaround can be added until such a solution is implemented.